### PR TITLE
Fix SpriteSwaps in the Look Behind tutorial

### DIFF
--- a/BaldiTexturePacks/BasePlugin.cs
+++ b/BaldiTexturePacks/BasePlugin.cs
@@ -18,7 +18,6 @@ using MTM101BaldAPI.SaveSystem;
 using UnityEngine.UI;
 using MidiPlayerTK;
 using BepInEx.Configuration;
-using System.Reflection;
 
 namespace BaldiTexturePacks
 {

--- a/BaldiTexturePacks/BasePlugin.cs
+++ b/BaldiTexturePacks/BasePlugin.cs
@@ -18,11 +18,12 @@ using MTM101BaldAPI.SaveSystem;
 using UnityEngine.UI;
 using MidiPlayerTK;
 using BepInEx.Configuration;
+using System.Reflection;
 
 namespace BaldiTexturePacks
 {
     [BepInDependency("mtm101.rulerp.bbplus.baldidevapi")]
-    [BepInPlugin("mtm101.rulerp.baldiplus.texturepacks", "Texture Packs", "3.2.0.1")]
+    [BepInPlugin("mtm101.rulerp.baldiplus.texturepacks", "Texture Packs", "3.2.0.2")]
     public partial class TexturePacksPlugin : BaseUnityPlugin
     {
         public static List<(string, bool)> packOrder = new List<(string, bool)>();
@@ -327,6 +328,7 @@ namespace BaldiTexturePacks
         {
             Harmony harmony = new Harmony("mtm101.rulerp.baldiplus.texturepacks");
             LoadingEvents.RegisterOnAssetsLoaded(this.Info, OnLoad(), LoadingEventOrder.Final);
+            spriteSwapsEnabled = Config.Bind("General", "Sprite Swaps", true, "If set to false, the sprite swap system will be disabled.\nThis WILL break packs, so only enable if SpriteSwaps are causing issues.");
             harmony.PatchAllConditionals();
             Log = this.Logger;
             Instance = this;
@@ -334,7 +336,6 @@ namespace BaldiTexturePacks
             AddReplacementTarget(gameObject.AddComponent<HardcodedTexturePackReplacements>());
             CustomOptionsCore.OnMenuInitialize += AddCategory;
             ModdedSaveSystem.AddSaveLoadAction(this, SaveHandler);
-            spriteSwapsEnabled = Config.Bind("General", "Sprite Swaps", true, "If set to false, the sprite swap system will be disabled.\nThis WILL break packs, so only enable if SpriteSwaps are causing issues.");
         }
 
         public void SaveHandler(bool isSave, string path)

--- a/BaldiTexturePacks/Patches/TutorialLookBackFixPatch.cs
+++ b/BaldiTexturePacks/Patches/TutorialLookBackFixPatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using UnityEngine;
+using MTM101BaldAPI;
+
+namespace BaldiTexturePacks.Patches
+{
+    [ConditionalPatchConfig("mtm101.rulerp.baldiplus.texturepacks", "General", "Sprite Swaps")]
+    [HarmonyPatch(typeof(TutorialGameManager), "BeginPlay")]
+    class LookBackFix
+    {
+        static void Postfix(AudioManager[] ___lookBackBaldi, ref SpriteRenderer[] ___lookBackRenderer)
+        {
+            for (int i = 0; i < ___lookBackRenderer.Length; i++)
+            {
+                ___lookBackBaldi[i].gameObject.SetActive(true);
+                ___lookBackRenderer[i] = ___lookBackRenderer[i].transform.Find("FakeRenderer").GetComponent<SpriteRenderer>();
+                ___lookBackBaldi[i].gameObject.SetActive(false);
+                ___lookBackRenderer[i].gameObject.SetActive(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patches the Tutorial level so the Look Behind section works properly with Sprite Swaps enabled. Implementing the patch in itself was pretty easy aside from user error