### PR TITLE
Extended SpriteSwap support.

### DIFF
--- a/BaldiTexturePacks/BaldiTexturePacks.csproj
+++ b/BaldiTexturePacks/BaldiTexturePacks.csproj
@@ -77,11 +77,17 @@
     <Reference Include="System.Diagnostics.StackTrace">
       <HintPath>..\Dependencies\System.Diagnostics.StackTrace.dll</HintPath>
     </Reference>
+    <Reference Include="System.Drawing.Common">
+    <HintPath>..\Dependencies\System.Drawing.Common.dll</HintPath>
+    </Reference>
     <Reference Include="System.EnterpriseServices">
       <HintPath>..\Dependencies\System.EnterpriseServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Extensions">
       <HintPath>..\Dependencies\System.Globalization.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\Dependencies\System.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel.Internals">
       <HintPath>..\Dependencies\System.ServiceModel.Internals.dll</HintPath>
@@ -335,6 +341,11 @@
     <Reference Include="UnityEngine.XRModule">
       <HintPath>..\Dependencies\UnityEngine.XRModule.dll</HintPath>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/BaldiTexturePacks/BasePlugin.cs
+++ b/BaldiTexturePacks/BasePlugin.cs
@@ -381,6 +381,7 @@ namespace BaldiTexturePacks
         {
             yield return 11;
             yield return "Getting base objects...";
+            // Activities
             AddManualReplacementTargetsFromResources<MathMachine>().Do(x =>
             {
                 validMovableComponents.AddRange(x.GetComponentsInChildren<TMP_Text>().Select(z => (Component)z.transform));
@@ -405,31 +406,10 @@ namespace BaldiTexturePacks
             {
                 validMovableComponents.AddRange(x.transform.Find("RendererBase").GetComponentsInChildren<SpriteRenderer>());
             });
+            // Events
             AddManualReplacementTargetsFromResources<FloodEvent>();
             AddManualReplacementTargetsFromResources<FogEvent>();
-            AddManualReplacementTargetsFromResources<HudManager>().Do(x => AddAllChildrenToMovables(x.transform));
-            AddManualReplacementTargetsFromResources<LookAtGuy>();
-            AddManualReplacementTargetsFromResources<DigitalClock>().Do(x =>
-            {
-                validMovableComponents.AddRange(x.GetComponentsInChildren<SpriteRenderer>());
-                validMovableComponents.AddRange(x.GetComponentsInChildren<Image>());
-            });
-            AddManualReplacementTargetsFromResources<ElevatorScreen>().Do(x => AddAllChildrenToMovables(x.transform));
-            AddManualReplacementTargetsFromResources<Item>().Do(x =>
-            {
-                if (x.transform.Find("RendererBase"))
-                {
-                    validMovableComponents.Add(x.transform.Find("RendererBase").GetComponentInChildren<SpriteRenderer>());
-                }
-            });
-            AddManualReplacementTargetsFromResources<BaldiBG>().Do(x =>
-            {
-                AddAllChildrenToMovables(x.transform);
-                if (x.GetComponent<CursorInitiator>())
-                {
-                    AddReplacementTarget(x.GetComponent<CursorInitiator>());
-                }
-            });
+            // Field Trip(s)
             AddManualReplacementTargetsFromResources<RendererContainer>().Do(x =>
             {
                 if (x.name == "PineTree_Bully")
@@ -439,6 +419,38 @@ namespace BaldiTexturePacks
                 else if (x.name == "CampFire(Clone)")
                 {
                     validMovableComponents.AddRange(x.transform.Find("Sprite").GetComponentsInChildren<SpriteRenderer>());
+                }
+            });
+            // UI
+            AddManualReplacementTargetsFromResources<HudManager>().Do(x => AddAllChildrenToMovables(x.transform));
+            AddManualReplacementTargetsFromResources<ElevatorScreen>().Do(x => AddAllChildrenToMovables(x.transform));
+            AddManualReplacementTargetsFromResources<BaldiBG>().Do(x =>
+            {
+                AddAllChildrenToMovables(x.transform);
+                if (x.GetComponent<CursorInitiator>())
+                {
+                    AddReplacementTarget(x.GetComponent<CursorInitiator>());
+                }
+            });
+            // Misc.
+            AddManualReplacementTargetsFromResources<LookAtGuy>();
+            AddManualReplacementTargetsFromResources<DigitalClock>().Do(x =>
+            {
+                validMovableComponents.AddRange(x.GetComponentsInChildren<SpriteRenderer>());
+                validMovableComponents.AddRange(x.GetComponentsInChildren<Image>());
+            });
+            AddManualReplacementTargetsFromResources<Item>().Do(x =>
+            {
+                if (x.transform.Find("RendererBase"))
+                {
+                    validMovableComponents.Add(x.transform.Find("RendererBase").GetComponentInChildren<SpriteRenderer>());
+                }
+            });
+            AddManualReplacementTargetsFromResources<Animator>().Do(x =>
+            {
+                if (x.name.StartsWith("ActivityExteriorSign_"))
+                {
+                    validMovableComponents.Add(x.transform.Find("SignBase").GetComponentInChildren<SpriteRenderer>());
                 }
             });
             baseElevatorScreen = Resources.FindObjectsOfTypeAll<ElevatorScreen>().First(x => x.GetInstanceID() >= 0 && x.gameObject.scene.name == null);
@@ -598,6 +610,10 @@ namespace BaldiTexturePacks
             });
 
             Resources.FindObjectsOfTypeAll<ClickableSpecialFunctionTrigger>().Where(x => x.name.StartsWith("Baldi_Tutorial")).Do(c =>
+            {
+                AddOverlaysToTransform(c.transform);
+            });
+            Resources.FindObjectsOfTypeAll<Animator>().Where(x => x.name.StartsWith("ActivityExteriorSign_")).Do(c =>
             {
                 AddOverlaysToTransform(c.transform);
             });

--- a/BaldiTexturePacks/BasePlugin.cs
+++ b/BaldiTexturePacks/BasePlugin.cs
@@ -430,6 +430,17 @@ namespace BaldiTexturePacks
                     AddReplacementTarget(x.GetComponent<CursorInitiator>());
                 }
             });
+            AddManualReplacementTargetsFromResources<RendererContainer>().Do(x =>
+            {
+                if (x.name == "PineTree_Bully")
+                {
+                    validMovableComponents.AddRange(x.transform.Find("Sprite").GetComponentsInChildren<SpriteRenderer>());
+                }
+                else if (x.name == "CampFire(Clone)")
+                {
+                    validMovableComponents.AddRange(x.transform.Find("Sprite").GetComponentsInChildren<SpriteRenderer>());
+                }
+            });
             baseElevatorScreen = Resources.FindObjectsOfTypeAll<ElevatorScreen>().First(x => x.GetInstanceID() >= 0 && x.gameObject.scene.name == null);
             yield return "Setting up file structures...";
             if (!Directory.Exists(packsPath))
@@ -596,6 +607,14 @@ namespace BaldiTexturePacks
                 AddOverlaysToTransform(c.transform);
             });
             Resources.FindObjectsOfTypeAll<RendererContainer>().Where(x => x.name == "FirstPrize_SpriteBase").Do(c =>
+            {
+                AddOverlaysToTransform(c.transform);
+            });
+            Resources.FindObjectsOfTypeAll<RendererContainer>().Where(x => x.name == "PineTree_Bully").Do(c =>
+            {
+                AddOverlaysToTransform(c.transform);
+            });
+            Resources.FindObjectsOfTypeAll<RendererContainer>().Where(x => x.name == "CampFire(Clone)").Do(c =>
             {
                 AddOverlaysToTransform(c.transform);
             });

--- a/BaldiTexturePacks/BasePlugin.cs
+++ b/BaldiTexturePacks/BasePlugin.cs
@@ -453,6 +453,7 @@ namespace BaldiTexturePacks
                     validMovableComponents.Add(x.transform.Find("SignBase").GetComponentInChildren<SpriteRenderer>());
                 }
             });
+            AddManualReplacementTargetsFromResources<Balloon>();
             baseElevatorScreen = Resources.FindObjectsOfTypeAll<ElevatorScreen>().First(x => x.GetInstanceID() >= 0 && x.gameObject.scene.name == null);
             yield return "Setting up file structures...";
             if (!Directory.Exists(packsPath))
@@ -640,6 +641,7 @@ namespace BaldiTexturePacks
             Resources.FindObjectsOfTypeAll<HappyBaldi>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
             Resources.FindObjectsOfTypeAll<TutorialGameManager>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
             Resources.FindObjectsOfTypeAll<BalloonBuster>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
+            Resources.FindObjectsOfTypeAll<Balloon>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
             Resources.FindObjectsOfTypeAll<BalloonBusterBalloon>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
             Resources.FindObjectsOfTypeAll<MatchActivityBalloon>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));
             Resources.FindObjectsOfTypeAll<PacketOMatic>().Where(x => x.GetInstanceID() >= 0).Do(x => AddOverlaysToTransform(x.transform));

--- a/BaldiTexturePacks/TexturePack.cs
+++ b/BaldiTexturePacks/TexturePack.cs
@@ -13,6 +13,8 @@ using System.Text;
 using UnityEngine;
 using BaldiTexturePacks.Legacy;
 
+using System.Runtime;
+
 namespace BaldiTexturePacks
 {
 
@@ -36,7 +38,6 @@ namespace BaldiTexturePacks
 
         [JsonProperty("Version")]
         public int versionNumber;
-
         public PackMeta()
         {
             name = "Unnamed";
@@ -100,6 +101,7 @@ namespace BaldiTexturePacks
         public TexturePack(string path)
         {
             metaData = JsonConvert.DeserializeObject<PackMeta>(File.ReadAllText(Path.Combine(path, "pack.json")));
+
             _path = path;
             string texturesPath = Path.Combine(path, "Textures");
             string soundPath = Path.Combine(path, "SoundObjects");
@@ -327,6 +329,7 @@ namespace BaldiTexturePacks
                 yield return "Reloading Localization...";
                 localizationData = JsonConvert.DeserializeObject<LocalizationData>(File.ReadAllText(localizationPath));
             }
+
             yield break;
         }
     }


### PR DESCRIPTION
To be specific, the commits add SpriteSwap support to the following:

- It's a Bully in the Camping Fieldtrip
- The campfire in the Camping Fieldtrip
- The Exterior Activity Signs (Possibly buggy)
- All other instances of the Balloons outside the Balloon Buster activity, as they were only patched through said activity originally.

It also slightly re-orders a few things in the backend. Shouldn't break anything.